### PR TITLE
Add missing dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,3 +14,5 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 5.0.1
+Imports:
+    plyr


### PR DESCRIPTION
Installs `plyr` if not already installed. Otherwise the package fails to install.